### PR TITLE
fix missing captcha on register screen

### DIFF
--- a/includes/captcha-on-register-form.php
+++ b/includes/captcha-on-register-form.php
@@ -40,6 +40,12 @@ class ncr_captcha_on_register extends ncr_base_class {
 	public function __construct() {
 
 		parent::__construct();
+		
+		// add Google API JS script on the login section of the site
+		add_action( 'login_enqueue_scripts', array( $this, 'uncr_header_script' ), 10, 2 );
+
+		// add CSS to make sure the Google Captcha fits nicely
+		add_action( 'login_enqueue_scripts', array( $this, 'uncr_wp_css' ), 10, 2 );
 
 		add_action( 'register_form', array( $this, 'uncr_display_captcha' ), 10, 2 );
 


### PR DESCRIPTION
I ran into the same issue as the user here: https://wordpress.org/support/topic/no-captcha-on-registerrecover-screens-if-not-enabled-on-login-screen/ so I went ahead and made the fix accordingly